### PR TITLE
Use intersection-observer polyfill for wider cross-browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "debug": "^3.2.6",
     "filestack-js": "^0.11.4",
+    "intersection-observer": "^0.5.1",
     "lodash": "^4.17.11",
     "pdfjs-dist": "^2.0.943",
     "vue": "^2.6.3"

--- a/src/directives/visible.js
+++ b/src/directives/visible.js
@@ -1,3 +1,4 @@
+import 'intersection-observer'
 import debug from "debug"
 const log = debug("app:directives/visible")
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3951,6 +3951,11 @@ internal-ip@^3.0.1:
     default-gateway "^2.6.0"
     ipaddr.js "^1.5.2"
 
+intersection-observer@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.5.1.tgz#e340fc56ce74290fe2b2394d1ce88c4353ac6dfa"
+  integrity sha512-Zd7Plneq82kiXFixs7bX62YnuZ0BMRci9br7io88LwDyF3V43cQMI+G5IiTlTNTt+LsDUppl19J/M2Fp9UkH6g==
+
 invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"


### PR DESCRIPTION
Fixes #10 